### PR TITLE
IE10-11 compatibility workaround

### DIFF
--- a/less/reflex/mixins.less
+++ b/less/reflex/mixins.less
@@ -40,7 +40,7 @@
 
 // defaults for auto cols
 .setupAutoCols() {
-    .flex(1, 0, 0);
+    .flex(1, 0, 0px); // a unit on last value is required by IE10-11
     width: auto !important;
     max-width: 100%;
 }


### PR DESCRIPTION
A unit on `flex-basis` property is required by IE10-11
https://github.com/philipwalton/flexbugs#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored
