### PR TITLE
Add Reflex prefix to visibility classes

### DIFF
--- a/scss/reflex/_mixins.scss
+++ b/scss/reflex/_mixins.scss
@@ -329,27 +329,27 @@
 
 @mixin responsive-visibility-helpers() {
     @if $visibility-helpers == true {
-        .hidden-xxs {
+        .#{$reflex-prefix}hidden-xxs {
             @media (max-width: $reflex-xxs-max) {
                 display: none !important;
             }
         }
-        .hidden-xs {
+        .#{$reflex-prefix}hidden-xs {
             @media (min-width: $reflex-xs) and (max-width: $reflex-xs-max) {
                 display: none !important;
             }
         }
-        .hidden-sm {
+        .#{$reflex-prefix}hidden-sm {
             @media (min-width: $reflex-sm) and (max-width: $reflex-sm-max) {
                 display: none !important;
             }
         }
-        .hidden-md {
+        .#{$reflex-prefix}hidden-md {
             @media (min-width: $reflex-md) and (max-width: $reflex-md-max) {
                 display: none !important;
             }
         }
-        .hidden-lg {
+        .#{$reflex-prefix}hidden-lg {
             @media (min-width: $reflex-lg) {
                 display: none !important;
             }


### PR DESCRIPTION
Adding the optional `.#{$reflex-prefix}` to the visibility helper classes.