### PR TITLE
Fixes: 'Deprecation Warning: Using / for division outside of calc() i…

### DIFF
--- a/scss/includes/_mixins.scss
+++ b/scss/includes/_mixins.scss
@@ -13,9 +13,9 @@
 @mixin calc-reflex-columns($index, $class, $type) {
     @if $type == width and $index > 0 {
         .#{$reflex-prefix}#{$class}#{$index} {
-            width: percentage(($index / $reflex-columns));
+            width: percentage(calc($index / $reflex-columns));
             @if $legacy-support == true {
-                *width: percentage(($index / $reflex-columns)) - .1; // ie7 css hack
+                *width: percentage(calc($index / $reflex-columns)) - .1; // ie7 css hack
             }
         }
     }
@@ -105,14 +105,14 @@
 // offset class generation mixins
 // --------------------------------------------------
 @mixin offset($index: 0) {
-    $offset: ($index / $reflex-columns);
+    $offset: calc($index / $reflex-columns);
     // convert to percentage only if not zero
     @if $offset != 0 {
         $offset: percentage($offset);
     }
     margin-left: $offset;
     @if $legacy-support == true {
-        *margin-left: percentage(($index / $reflex-columns)) - .1; // ie7 css hack
+        *margin-left: percentage(calc($index / $reflex-columns)) - .1; // ie7 css hack
     }
 }
 

--- a/scss/includes/_mixins.scss
+++ b/scss/includes/_mixins.scss
@@ -5,6 +5,7 @@
 // --------------------------------------------------
 // reflex grid generation mixins
 // --------------------------------------------------
+@use "sass:math";
 
 @mixin make-reflex-grid($class) {
     @include loop-reflex-columns($reflex-columns, $class, width);
@@ -13,9 +14,9 @@
 @mixin calc-reflex-columns($index, $class, $type) {
     @if $type == width and $index > 0 {
         .#{$reflex-prefix}#{$class}#{$index} {
-            width: percentage(calc($index / $reflex-columns));
+            width: percentage(math.div($index, $reflex-columns));
             @if $legacy-support == true {
-                *width: percentage(calc($index / $reflex-columns)) - .1; // ie7 css hack
+                *width: percentage(math.div($index, $reflex-columns)) - .1; // ie7 css hack
             }
         }
     }
@@ -105,14 +106,14 @@
 // offset class generation mixins
 // --------------------------------------------------
 @mixin offset($index: 0) {
-    $offset: calc($index / $reflex-columns);
+    $offset: math.div($index, $reflex-columns);
     // convert to percentage only if not zero
     @if $offset != 0 {
         $offset: percentage($offset);
     }
     margin-left: $offset;
     @if $legacy-support == true {
-        *margin-left: percentage(calc($index / $reflex-columns)) - .1; // ie7 css hack
+        *margin-left: percentage(math.div($index, $reflex-columns)) - .1; // ie7 css hack
     }
 }
 


### PR DESCRIPTION
Addresses Issue 68:
https://github.com/leejordan/reflex/issues/68

Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.